### PR TITLE
cite developer.rchain.coop for current info

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -14,6 +14,15 @@ RChain Platform Architecture
 
 .. _Creative Commons Attribution 4.0 International (CC BY 4.0) License: https://creativecommons.org/licenses/by/4.0/
 
+Notice: Updated Details Available
+=================================
+
+For details on the platform as it is built, see `developer.rchain.coop`__ including
+`rchain/rchain`__ open source github repository, Rholang tutorial, and project status.
+
+__ https://developer.rchain.coop/
+__ https://github.com/rchain/rchain
+
 
 Abstract
 ===============================================


### PR DESCRIPTION
I think @edeykholt suggested this. In any case, unless / until we update the doc, it's important to let people know that current details are elsewhere.