### PR TITLE
install sphinx dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Install Sphinx, etc
 --------------------------------------------------------------------------------
 For OSX/Linux users (based on instructions here: https://read-the-docs.readthedocs.org/en/latest/getting_started.html)
 
-* From command line: ``sudo pip install sphinx``
+* From command line: ``sudo pip install sphinx sphinxcontrib-bibtex``
 
 For Windows users:
 


### PR DESCRIPTION
Motiviation- make install fails with the error: exception: No module named 'sphinxcontrib.bibtex
solution:  install sphinxcontrib-bibtex dependency